### PR TITLE
Implement a `pop_item` filter

### DIFF
--- a/lib/jekyll/filters.rb
+++ b/lib/jekyll/filters.rb
@@ -257,6 +257,17 @@ module Jekyll
       new_ary
     end
 
+    def pop_item(array, num = nil)
+      return array unless array.is_a?(Array)
+
+      unless num.nil?
+        num = Liquid::Utils.to_integer(num)
+        array.pop(num)
+      else
+        array.pop
+      end
+    end
+
     def push(array, input)
       return array unless array.is_a?(Array)
 

--- a/test/test_filters.rb
+++ b/test/test_filters.rb
@@ -1256,6 +1256,26 @@ class TestFilters < JekyllUnitTest
       end
     end
 
+    context "pop_item filter" do
+      should "return the last item in the array by default" do
+        assert_equal "greeting", @filter.pop_item(%w(just a friendly greeting))
+      end
+      should "have the input array retain updates" do
+        greeting = %w(just a friendly greeting)
+        @filter.pop_item(greeting)
+        assert_equal %w(just a friendly), greeting
+      end
+      should "return multiple items popped" do
+        assert_equal %w(friendly greeting), @filter.pop_item(%w(just a friendly greeting), 2)
+      end
+      should "return an array when a number is specified" do
+        assert_equal %w(greeting), @filter.pop_item(%w(just a friendly greeting), 1)
+      end
+      should "cast string inputs for numbers into actual numbers" do
+        assert_equal %w(friendly greeting), @filter.pop_item(%w(just a friendly greeting), "2")
+      end
+    end
+
     context "sample filter" do
       should "return a random item from the array" do
         input = %w(hey there bernie)


### PR DESCRIPTION
This is just a proxy for Array#pop in Ruby. We're using nil as a
indicator that a number was not passed. If we use 1 as the default,
Array#pop always returns an array. If the number `1` is passed in, then
we just let Array#pop always return an array.

<!--
  Thanks for creating a Pull Request! Before you submit, please make sure
  you've done the following:

  - I read the contributing document at https://jekyllrb.com/docs/contributing/
-->

<!--
  Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐛 bug fix. -->
<!-- This is a 🙋 feature or enhancement. -->
<!-- This is a 🔦 documentation change. -->

<!--
  Before you submit this pull request, make sure to have a look at the following
  checklist. If you don't know how to do some of these, that's fine! Submit
  your pull request and we will help you out on the way.

  - I've added tests (if it's a bug, feature or enhancement)
  - I've adjusted the documentation (if it's a feature or enhancement)
  - The test suite passes locally (run `script/cibuild` to verify this)
-->

## Summary

<!--
  Provide a description of what your pull request changes.
-->

## Context

<!--
  Is this related to any GitHub issue(s)?

  You can use keywords to automatically close the related issue.
  For example, (all of) the following will close issue #4567 when your PR is merged.

  Closes #4567
  Fixes #4567
  Resolves #4567

  Use any one of the above as applicable.
-->
